### PR TITLE
adds support for loading yara rules from the Karton S3 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,9 @@ And run the karton service by pointing it to your [YARA](https://virustotal.gith
 ```shell
 $ karton-yaramatcher --rules yara_rule_directory
 ```
+or if your yara rules are in your Karton S3 storage (MinIO)
+```shell
+$ karton-yaramatcher --bucket yara_rule_bucket
+```
 
 ![Co-financed by the Connecting Europe Facility by of the European Union](https://www.cert.pl/wp-content/uploads/2019/02/en_horizontal_cef_logo-1.png)


### PR DESCRIPTION
In some situations it can be helpful to load Yara rules from the Karton S3 storage instead of mapping a volume to the docker container (for example if you deploy the Karton ecosystem on OpenShift).

Maybe my solution has room for improvement:-)

What do you think?