### PR TITLE
Can load Yara rules as a single index file

### DIFF
--- a/karton/yaramatcher/yaramatcher.py
+++ b/karton/yaramatcher/yaramatcher.py
@@ -53,7 +53,7 @@ class YaraHandler:
             rules_dict = {str(i): rule_paths[i] for i in range(0, len(rule_paths))}
         # if it's an index file (e.g., https://github.com/Yara-Rules/rules)
         elif os.path.isfile(yara_path) and yara_path.endswith(".yar"):
-            rules_dict = { "0": yara_path }
+            rules_dict = {"0": yara_path}
         else:
             raise RuntimeError("Please supply a valid path to Yara rule(s)")
 

--- a/karton/yaramatcher/yaramatcher.py
+++ b/karton/yaramatcher/yaramatcher.py
@@ -60,7 +60,7 @@ class YaraHandler:
         log.info("Compiling Yara rules. This might take a few moments...")
         # Hold yara.Rules object with the compiled rules
         self.rules = yara.compile(filepaths=rules_dict)
-        log.info("Loaded {} yara rules".format(len(rule_paths)))
+        log.info("Loaded yara rules from {} files".format(len(rules_dict)))
 
     def get_matches(self, content) -> yara.Rules:
         """Use the compiled Yara rules and scan them against a sample

--- a/karton/yaramatcher/yaramatcher.py
+++ b/karton/yaramatcher/yaramatcher.py
@@ -49,7 +49,7 @@ class YaraHandler:
             if not rule_paths:
                 raise RuntimeError("The yara rule directory is empty")
 
-            # Convert the list to a dict {"0": "rules/rule1.yar", "1": "rules/folder/rul...
+            # Convert the list to a dict {"0": "rules/rule1.yar", "1": "rules/dir/rul...
             rules_dict = {str(i): rule_paths[i] for i in range(0, len(rule_paths))}
         # if it's an index file (e.g., https://github.com/Yara-Rules/rules)
         elif os.path.isfile(yara_path) and yara_path.endswith(".yar"):

--- a/karton/yaramatcher/yaramatcher.py
+++ b/karton/yaramatcher/yaramatcher.py
@@ -36,19 +36,26 @@ class YaraHandler:
         yara_path = path or "rules"
         rule_paths = []
 
-        for root, _, f_names in os.walk(yara_path):
-            # Recursively collect paths for yara rules in the folder
-            for f in f_names:
-                # Ignore non Yara files based on extension
-                if not f.endswith(".yar") and not f.endswith(".yara"):
-                    continue
-                rule_paths.append(os.path.join(root, f))
+        # if it's a directory, then walk recursively
+        if os.path.isdir(yara_path):
+            for root, _, f_names in os.walk(yara_path):
+                # Recursively collect paths for yara rules in the folder
+                for f in f_names:
+                    # Ignore non Yara files based on extension
+                    if not f.endswith(".yar") and not f.endswith(".yara"):
+                        continue
+                    rule_paths.append(os.path.join(root, f))
 
-        if not rule_paths:
-            raise RuntimeError("The yara rule directory is empty")
+            if not rule_paths:
+                raise RuntimeError("The yara rule directory is empty")
 
-        # Convert the list to a dict {"0": "rules/rule1.yar", "1": "rules/folder/rul...
-        rules_dict = {str(i): rule_paths[i] for i in range(0, len(rule_paths))}
+            # Convert the list to a dict {"0": "rules/rule1.yar", "1": "rules/folder/rul...
+            rules_dict = {str(i): rule_paths[i] for i in range(0, len(rule_paths))}
+        # if it's an index file (e.g., https://github.com/Yara-Rules/rules)
+        elif os.path.isfile(yara_path) and yara_path.endswith(".yar"):
+            rules_dict = { "0": yara_path }
+        else:
+            raise RuntimeError("Please supply a valid path to Yara rule(s)")
 
         log.info("Compiling Yara rules. This might take a few moments...")
         # Hold yara.Rules object with the compiled rules


### PR DESCRIPTION
Yara rules repositories can have complex dependencies that a simple recursive rule loading is unable to cope with. That's why repos like https://github.com/Yara-Rules/rules have "index" rules, that import sub-rules in well-defined order.

This PR checks if the path supplied via `--rules path` is a file (and in this case it only complies that index rule) or a directory (and in that case it proceeds as usual, recursively).